### PR TITLE
feat: How to use the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@ To run the generator, you must clone it.
 From the terminal cd into the `chrome-extension-generator` directory and run:
 
 ```bash
-npm install
-npm link
+npm install && npm link
 ```
 
 This will give you global access to the generator.
 
-Now go to the root directory where the project will be created:
+Now go to the root directory where the project will be created and run:
 
 ```bash
 create-chrome-extension
@@ -23,11 +22,13 @@ This will run the generator (provide inputs as required).
 
 Once the project has been built, you will be prompted to run commands to install dependencies and run linters.
 
-To open in VS Code:
+When in the extension directory, open in VS Code with:
 
 ```bash
 code .
 ```
+
+(Here is how to set up the [VS Code command line interface](https://code.visualstudio.com/docs/editor/command-line))
 
 [To add the new repo to GitHub using Git](https://docs.github.com/en/migrations/importing-source-code/using-the-command-line-to-import-source-code/adding-locally-hosted-code-to-github)
 
@@ -66,3 +67,23 @@ Content scripts do not support ES modules. You need to declare your functions in
    ```javascript
    const result = window.myUsefulFunction()
    ```
+
+## How to work with your new extension
+
+### Tips and tricks for development
+
+- Make sure your manifest has the [right permissions](https://developer.chrome.com/docs/extensions/reference/permissions-list) for what you're trying to achieve. Error messages don't explicitely mention that you're missing a permission.
+- Once you've (re)loaded your extension locally, try to reload the web page you're working on, that may solve some communication issues between the service worker and the content script.
+- If you have weird errors, don't hesitate to `Remove` and `Load Unpacked` the extension again, particularly if you've modified the manifest.
+
+### Local use
+
+You can use your extension locally in Chrome (or Chromium-based browsers such as Brave) as follows:
+
+- Go to the menu (burger or three dots in the top right corner) then `Extensions > Manage Extensions`.
+- Make sure the `Developer Mode` is activated (toggle in the top right corner)
+- Click `Load Unpacked` and point to the directory hosting your extension code (by default `publish`, it's the directory containing your `manifest.json`)
+
+### Distribution on the Chrome Web Store
+
+We've written a [short article](https://people-and-code.com/how-to/build-and-distribute-a-chrome-extension) about the main steps and pitfalls to publishing your extension on the [Chrome Web Store](https://chromewebstore.google.com/).


### PR DESCRIPTION
More detailed README with some extra tips and tricks and all the corrections discussed in the other PR. 

Apparently, in MacOS. you need to add the `code` command to the paths. Anyway, I'm pointing to the official doc by MS. 